### PR TITLE
Import Foundation

### DIFF
--- a/ZXingObjC/ZXMultiFormatReader.h
+++ b/ZXingObjC/ZXMultiFormatReader.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
 #import "ZXReader.h"
 
 @class ZXDecodeHints;

--- a/ZXingObjC/ZXMultiFormatWriter.h
+++ b/ZXingObjC/ZXMultiFormatWriter.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
 #import "ZXWriter.h"
 
 /**

--- a/ZXingObjC/core/ZXReader.h
+++ b/ZXingObjC/core/ZXReader.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBinaryBitmap, ZXDecodeHints, ZXResult;
 
 /**

--- a/ZXingObjC/core/ZXWriter.h
+++ b/ZXingObjC/core/ZXWriter.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
 #import "ZXBarcodeFormat.h"
 
 @class ZXBitMatrix, ZXEncodeHints;


### PR DESCRIPTION
Corrected the problem by defining the dependencies in each header file. Error received in these headers: "Cannot find protocol declaration for 'NSObject'"

(Cannot use in Swift without using CocoaPods or Carthage.)