### PR TITLE
Fix swift crash in ZXMultiFormatWriter.m

### DIFF
--- a/ZXingObjC/ZXMultiFormatWriter.m
+++ b/ZXingObjC/ZXMultiFormatWriter.m
@@ -121,7 +121,15 @@
       if (error) *error = [NSError errorWithDomain:ZXErrorDomain code:ZXWriterError userInfo:@{NSLocalizedDescriptionKey: @"No encoder available for format"}];
       return nil;
   }
-  return [writer encode:contents format:format width:width height:height hints:hints error:error];
+
+  @try {
+    return [writer encode:contents format:format width:width height:height hints:hints error:error];
+  } @catch (NSException *exception) {
+    if (error) {
+        *error = [NSError errorWithDomain:ZXErrorDomain code:ZXWriterError userInfo:@{NSLocalizedDescriptionKey: exception.reason}];
+    }
+    return nil;
+  }
 }
 
 @end


### PR DESCRIPTION
Hello!
I'm using this project in the Swift app. Since it's not possible to catch Objc exceptions in Swift the app crashes when the provided code doesn't pass some validations, eg. when `itf` code has odd number of digits:
```swift
if (length % 2 != 0) {
    [NSException raise:NSInvalidArgumentException format:@"The length of the input should be even"];
}
```

For a nicer compatibility with Swift I added this small wrapper that bridges nicely to swift so a *try catch* block in Swift can actually catch the error and handle it.

The tests are still passing, I was thinking about adding a Swift test target to test this, but it looked like an overkill for this simple fix.

Cheers, lemme know if this is alright!