### PR TITLE
Add Swift Package Manager integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,71 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ZXingObjC",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "ZXingObjC",
+            targets: ["ZXingObjC"]
+        ),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "ZXingObjC",
+            dependencies: [],
+            path: "ZXingObjC",
+            publicHeadersPath: "include",
+            cxxSettings: [
+                .headerSearchPath("aztec"),
+                .headerSearchPath("aztec/decoder"),
+                .headerSearchPath("aztec/detector"),
+                .headerSearchPath("aztec/encoder"),
+                
+                .headerSearchPath("client"),
+                .headerSearchPath("client/result"),
+                
+                .headerSearchPath("common"),
+                .headerSearchPath("common/detector"),
+                .headerSearchPath("common/reedsolomon"),
+                
+                .headerSearchPath("core"),
+                
+                .headerSearchPath("datamatrix"),
+                .headerSearchPath("datamatrix/decoder"),
+                .headerSearchPath("datamatrix/detector"),
+                .headerSearchPath("datamatrix/encoder"),
+                
+                .headerSearchPath("maxicode"),
+                .headerSearchPath("maxicode/decoder"),
+                
+                .headerSearchPath("multi"),
+                
+                .headerSearchPath("oned"),
+                .headerSearchPath("oned/rss"),
+                .headerSearchPath("oned/rss/expanded"),
+                .headerSearchPath("oned/rss/expanded/decoders"),
+                
+                .headerSearchPath("pdf417"),
+                .headerSearchPath("pdf417/decoder"),
+                .headerSearchPath("pdf417/decoder/ec"),
+                .headerSearchPath("pdf417/detector"),
+                .headerSearchPath("pdf417/encoder"),
+                
+                .headerSearchPath("qrcode"),
+                .headerSearchPath("qrcode/decoder"),
+                .headerSearchPath("qrcode/detector"),
+                .headerSearchPath("qrcode/encoder"),
+                .headerSearchPath("qrcode/multi"),
+                .headerSearchPath("qrcode/multi/detector"),
+            ]
+        )
+    ]
+)

--- a/ZXingObjC/aztec/detector/ZXAztecDetector.h
+++ b/ZXingObjC/aztec/detector/ZXAztecDetector.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXAztecPoint : NSObject
 
 @property (nonatomic, assign, readonly) int x;

--- a/ZXingObjC/aztec/encoder/ZXAztecCode.h
+++ b/ZXingObjC/aztec/encoder/ZXAztecCode.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitMatrix;
 
 /**

--- a/ZXingObjC/aztec/encoder/ZXAztecHighLevelEncoder.h
+++ b/ZXingObjC/aztec/encoder/ZXAztecHighLevelEncoder.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 extern NSArray *ZX_AZTEC_MODE_NAMES;
 
 extern const int ZX_AZTEC_MODE_UPPER;

--- a/ZXingObjC/aztec/encoder/ZXAztecToken.h
+++ b/ZXingObjC/aztec/encoder/ZXAztecToken.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitArray, ZXByteArray;
 
 @interface ZXAztecToken : NSObject

--- a/ZXingObjC/client/ZXCGImageLuminanceSourceInfo.h
+++ b/ZXingObjC/client/ZXCGImageLuminanceSourceInfo.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 typedef enum {
   ZXCGImageLuminanceSourceNormal = 0,
   ZXCGImageLuminanceSourceLuma,

--- a/ZXingObjC/client/result/ZXResultParser.h
+++ b/ZXingObjC/client/result/ZXResultParser.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXParsedResult, ZXResult;
 
 /**

--- a/ZXingObjC/common/ZXBitArray.h
+++ b/ZXingObjC/common/ZXBitArray.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXByteArray, ZXIntArray;
 
 /**

--- a/ZXingObjC/common/ZXBitMatrix.h
+++ b/ZXingObjC/common/ZXBitMatrix.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitArray, ZXIntArray;
 
 /**

--- a/ZXingObjC/common/ZXBitSource.h
+++ b/ZXingObjC/common/ZXBitSource.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXByteArray;
 
 /**

--- a/ZXingObjC/common/ZXBoolArray.h
+++ b/ZXingObjC/common/ZXBoolArray.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXBoolArray : NSObject
 
 @property (nonatomic, assign, readonly) BOOL *array;

--- a/ZXingObjC/common/ZXByteArray.h
+++ b/ZXingObjC/common/ZXByteArray.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXByteArray : NSObject
 
 @property (nonatomic, assign, readonly) int8_t *array;

--- a/ZXingObjC/common/ZXCharacterSetECI.h
+++ b/ZXingObjC/common/ZXCharacterSetECI.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Encapsulates a Character Set ECI, according to "Extended Channel Interpretations" 5.3.1.1
  * of ISO 18004.

--- a/ZXingObjC/common/ZXDecimal.h
+++ b/ZXingObjC/common/ZXDecimal.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Drop-in replacement for `NSDecimalNumber`.
  * @see ZXPDF417DecodedBitStreamParser.m#L696

--- a/ZXingObjC/common/ZXIntArray.h
+++ b/ZXingObjC/common/ZXIntArray.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXIntArray : NSObject <NSCopying>
 
 @property (nonatomic, assign, readonly) int32_t *array;

--- a/ZXingObjC/common/ZXPerspectiveTransform.h
+++ b/ZXingObjC/common/ZXPerspectiveTransform.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * This class implements a perspective transform in two dimensions. Given four source and four
  * destination points, it will compute the transformation implied between them. The code is based

--- a/ZXingObjC/common/detector/ZXMathUtils.h
+++ b/ZXingObjC/common/detector/ZXMathUtils.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXMathUtils : NSObject
 
 /**

--- a/ZXingObjC/common/reedsolomon/ZXGenericGF.h
+++ b/ZXingObjC/common/reedsolomon/ZXGenericGF.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXGenericGFPoly;
 
 /**

--- a/ZXingObjC/core/ZXBinaryBitmap.h
+++ b/ZXingObjC/core/ZXBinaryBitmap.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBinarizer, ZXBitArray, ZXBitMatrix;
 
 /**

--- a/ZXingObjC/core/ZXByteMatrix.h
+++ b/ZXingObjC/core/ZXByteMatrix.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXByteMatrix : NSObject
 
 @property (nonatomic, assign, readonly) int8_t **array;

--- a/ZXingObjC/core/ZXDecodeHints.h
+++ b/ZXingObjC/core/ZXDecodeHints.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
 #import "ZXBarcodeFormat.h"
 
 @protocol ZXResultPointCallback;

--- a/ZXingObjC/core/ZXDimension.h
+++ b/ZXingObjC/core/ZXDimension.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Simply encapsulates a width and height.
  */

--- a/ZXingObjC/core/ZXEncodeHints.h
+++ b/ZXingObjC/core/ZXEncodeHints.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Enumeration for DataMatrix symbol shape hint. It can be used to force square or rectangular
  * symbols.

--- a/ZXingObjC/core/ZXErrors.h
+++ b/ZXingObjC/core/ZXErrors.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #define ZXErrorDomain @"ZXErrorDomain"
 
 enum {

--- a/ZXingObjC/core/ZXResultPoint.h
+++ b/ZXingObjC/core/ZXResultPoint.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Encapsulates a point of interest in an image containing a barcode. Typically, this
  * would be the location of a finder pattern or the corner of the barcode, for example.

--- a/ZXingObjC/datamatrix/decoder/ZXDataMatrixVersion.h
+++ b/ZXingObjC/datamatrix/decoder/ZXDataMatrixVersion.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Encapsulates a set of error-correction blocks in one symbol version. Most versions will
  * use blocks of differing sizes within one version, so, this encapsulates the parameters for

--- a/ZXingObjC/datamatrix/detector/ZXDataMatrixDetector.h
+++ b/ZXingObjC/datamatrix/detector/ZXDataMatrixDetector.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitMatrix, ZXDetectorResult, ZXWhiteRectangleDetector;
 
 /**

--- a/ZXingObjC/datamatrix/encoder/ZXDataMatrixDefaultPlacement.h
+++ b/ZXingObjC/datamatrix/encoder/ZXDataMatrixDefaultPlacement.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Symbol Character Placement Program. Adapted from Annex M.1 in ISO/IEC 16022:2000(E).
  */

--- a/ZXingObjC/datamatrix/encoder/ZXDataMatrixEncoder.h
+++ b/ZXingObjC/datamatrix/encoder/ZXDataMatrixEncoder.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXDataMatrixEncoderContext;
 
 @protocol ZXDataMatrixEncoder <NSObject>

--- a/ZXingObjC/datamatrix/encoder/ZXDataMatrixErrorCorrection.h
+++ b/ZXingObjC/datamatrix/encoder/ZXDataMatrixErrorCorrection.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXDataMatrixSymbolInfo;
 
 /**

--- a/ZXingObjC/include/ZXingObjC/ZXAbstractDoCoMoResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAbstractDoCoMoResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXAbstractDoCoMoResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXAbstractExpandedDecoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAbstractExpandedDecoder.h
@@ -1,0 +1,1 @@
+../../oned/rss/expanded/decoders/ZXAbstractExpandedDecoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXAbstractRSSReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAbstractRSSReader.h
@@ -1,0 +1,1 @@
+../../oned/rss/ZXAbstractRSSReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXAddressBookAUResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAddressBookAUResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXAddressBookAUResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXAddressBookDoCoMoResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAddressBookDoCoMoResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXAddressBookDoCoMoResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXAddressBookParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAddressBookParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXAddressBookParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecCode.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecCode.h
@@ -1,0 +1,1 @@
+../../aztec/encoder/ZXAztecCode.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecDecoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecDecoder.h
@@ -1,0 +1,1 @@
+../../aztec/decoder/ZXAztecDecoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecDetector.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecDetector.h
@@ -1,0 +1,1 @@
+../../aztec/detector/ZXAztecDetector.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecDetectorResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecDetectorResult.h
@@ -1,0 +1,1 @@
+../../aztec/ZXAztecDetectorResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecEncoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecEncoder.h
@@ -1,0 +1,1 @@
+../../aztec/encoder/ZXAztecEncoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecHighLevelEncoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecHighLevelEncoder.h
@@ -1,0 +1,1 @@
+../../aztec/encoder/ZXAztecHighLevelEncoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecReader.h
@@ -1,0 +1,1 @@
+../../aztec/ZXAztecReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXAztecWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXAztecWriter.h
@@ -1,0 +1,1 @@
+../../aztec/ZXAztecWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXBarcodeFormat.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBarcodeFormat.h
@@ -1,0 +1,1 @@
+../../core/ZXBarcodeFormat.h

--- a/ZXingObjC/include/ZXingObjC/ZXBinarizer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBinarizer.h
@@ -1,0 +1,1 @@
+../../core/ZXBinarizer.h

--- a/ZXingObjC/include/ZXingObjC/ZXBinaryBitmap.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBinaryBitmap.h
@@ -1,0 +1,1 @@
+../../core/ZXBinaryBitmap.h

--- a/ZXingObjC/include/ZXingObjC/ZXBitArray.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBitArray.h
@@ -1,0 +1,1 @@
+../../common/ZXBitArray.h

--- a/ZXingObjC/include/ZXingObjC/ZXBitMatrix.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBitMatrix.h
@@ -1,0 +1,1 @@
+../../common/ZXBitMatrix.h

--- a/ZXingObjC/include/ZXingObjC/ZXBitSource.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBitSource.h
@@ -1,0 +1,1 @@
+../../common/ZXBitSource.h

--- a/ZXingObjC/include/ZXingObjC/ZXBizcardResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBizcardResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXBizcardResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXBookmarkDoCoMoResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBookmarkDoCoMoResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXBookmarkDoCoMoResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXBoolArray.h
+++ b/ZXingObjC/include/ZXingObjC/ZXBoolArray.h
@@ -1,0 +1,1 @@
+../../common/ZXBoolArray.h

--- a/ZXingObjC/include/ZXingObjC/ZXByQuadrantReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXByQuadrantReader.h
@@ -1,0 +1,1 @@
+../../multi/ZXByQuadrantReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXByteArray.h
+++ b/ZXingObjC/include/ZXingObjC/ZXByteArray.h
@@ -1,0 +1,1 @@
+../../common/ZXByteArray.h

--- a/ZXingObjC/include/ZXingObjC/ZXByteMatrix.h
+++ b/ZXingObjC/include/ZXingObjC/ZXByteMatrix.h
@@ -1,0 +1,1 @@
+../../core/ZXByteMatrix.h

--- a/ZXingObjC/include/ZXingObjC/ZXCGImageLuminanceSource.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCGImageLuminanceSource.h
@@ -1,0 +1,1 @@
+../../client/ZXCGImageLuminanceSource.h

--- a/ZXingObjC/include/ZXingObjC/ZXCGImageLuminanceSourceInfo.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCGImageLuminanceSourceInfo.h
@@ -1,0 +1,1 @@
+../../client/ZXCGImageLuminanceSourceInfo.h

--- a/ZXingObjC/include/ZXingObjC/ZXCalendarParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCalendarParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXCalendarParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXCapture.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCapture.h
@@ -1,0 +1,1 @@
+../../client/ZXCapture.h

--- a/ZXingObjC/include/ZXingObjC/ZXCaptureDelegate.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCaptureDelegate.h
@@ -1,0 +1,1 @@
+../../client/ZXCaptureDelegate.h

--- a/ZXingObjC/include/ZXingObjC/ZXCharacterSetECI.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCharacterSetECI.h
@@ -1,0 +1,1 @@
+../../common/ZXCharacterSetECI.h

--- a/ZXingObjC/include/ZXingObjC/ZXCodaBarReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCodaBarReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXCodaBarReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXCodaBarWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCodaBarWriter.h
@@ -1,0 +1,1 @@
+../../oned/ZXCodaBarWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXCode128Reader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCode128Reader.h
@@ -1,0 +1,1 @@
+../../oned/ZXCode128Reader.h

--- a/ZXingObjC/include/ZXingObjC/ZXCode128Writer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCode128Writer.h
@@ -1,0 +1,1 @@
+../../oned/ZXCode128Writer.h

--- a/ZXingObjC/include/ZXingObjC/ZXCode39Reader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCode39Reader.h
@@ -1,0 +1,1 @@
+../../oned/ZXCode39Reader.h

--- a/ZXingObjC/include/ZXingObjC/ZXCode39Writer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCode39Writer.h
@@ -1,0 +1,1 @@
+../../oned/ZXCode39Writer.h

--- a/ZXingObjC/include/ZXingObjC/ZXCode93Reader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXCode93Reader.h
@@ -1,0 +1,1 @@
+../../oned/ZXCode93Reader.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixDecoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixDecoder.h
@@ -1,0 +1,1 @@
+../../datamatrix/decoder/ZXDataMatrixDecoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixDefaultPlacement.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixDefaultPlacement.h
@@ -1,0 +1,1 @@
+../../datamatrix/encoder/ZXDataMatrixDefaultPlacement.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixDetector.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixDetector.h
@@ -1,0 +1,1 @@
+../../datamatrix/detector/ZXDataMatrixDetector.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixEdifactEncoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixEdifactEncoder.h
@@ -1,0 +1,1 @@
+../../datamatrix/encoder/ZXDataMatrixEdifactEncoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixEncoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixEncoder.h
@@ -1,0 +1,1 @@
+../../datamatrix/encoder/ZXDataMatrixEncoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixEncoderContext.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixEncoderContext.h
@@ -1,0 +1,1 @@
+../../datamatrix/encoder/ZXDataMatrixEncoderContext.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixErrorCorrection.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixErrorCorrection.h
@@ -1,0 +1,1 @@
+../../datamatrix/encoder/ZXDataMatrixErrorCorrection.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixHighLevelEncoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixHighLevelEncoder.h
@@ -1,0 +1,1 @@
+../../datamatrix/encoder/ZXDataMatrixHighLevelEncoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixReader.h
@@ -1,0 +1,1 @@
+../../datamatrix/ZXDataMatrixReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixSymbolInfo.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixSymbolInfo.h
@@ -1,0 +1,1 @@
+../../datamatrix/encoder/ZXDataMatrixSymbolInfo.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixVersion.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixVersion.h
@@ -1,0 +1,1 @@
+../../datamatrix/decoder/ZXDataMatrixVersion.h

--- a/ZXingObjC/include/ZXingObjC/ZXDataMatrixWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDataMatrixWriter.h
@@ -1,0 +1,1 @@
+../../datamatrix/ZXDataMatrixWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXDecodeHints.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDecodeHints.h
@@ -1,0 +1,1 @@
+../../core/ZXDecodeHints.h

--- a/ZXingObjC/include/ZXingObjC/ZXDecoderResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDecoderResult.h
@@ -1,0 +1,1 @@
+../../common/ZXDecoderResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXDefaultGridSampler.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDefaultGridSampler.h
@@ -1,0 +1,1 @@
+../../common/ZXDefaultGridSampler.h

--- a/ZXingObjC/include/ZXingObjC/ZXDetectorResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDetectorResult.h
@@ -1,0 +1,1 @@
+../../common/ZXDetectorResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXDimension.h
+++ b/ZXingObjC/include/ZXingObjC/ZXDimension.h
@@ -1,0 +1,1 @@
+../../core/ZXDimension.h

--- a/ZXingObjC/include/ZXingObjC/ZXEAN13Reader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEAN13Reader.h
@@ -1,0 +1,1 @@
+../../oned/ZXEAN13Reader.h

--- a/ZXingObjC/include/ZXingObjC/ZXEAN13Writer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEAN13Writer.h
@@ -1,0 +1,1 @@
+../../oned/ZXEAN13Writer.h

--- a/ZXingObjC/include/ZXingObjC/ZXEAN8Reader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEAN8Reader.h
@@ -1,0 +1,1 @@
+../../oned/ZXEAN8Reader.h

--- a/ZXingObjC/include/ZXingObjC/ZXEAN8Writer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEAN8Writer.h
@@ -1,0 +1,1 @@
+../../oned/ZXEAN8Writer.h

--- a/ZXingObjC/include/ZXingObjC/ZXEmailAddressParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEmailAddressParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXEmailAddressParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXEmailAddressResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEmailAddressResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXEmailAddressResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXEmailDoCoMoResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEmailDoCoMoResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXEmailDoCoMoResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXEncodeHints.h
+++ b/ZXingObjC/include/ZXingObjC/ZXEncodeHints.h
@@ -1,0 +1,1 @@
+../../core/ZXEncodeHints.h

--- a/ZXingObjC/include/ZXingObjC/ZXErrors.h
+++ b/ZXingObjC/include/ZXingObjC/ZXErrors.h
@@ -1,0 +1,1 @@
+../../core/ZXErrors.h

--- a/ZXingObjC/include/ZXingObjC/ZXExpandedProductParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXExpandedProductParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXExpandedProductParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXExpandedProductResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXExpandedProductResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXExpandedProductResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXGenericGF.h
+++ b/ZXingObjC/include/ZXingObjC/ZXGenericGF.h
@@ -1,0 +1,1 @@
+../../common/reedsolomon/ZXGenericGF.h

--- a/ZXingObjC/include/ZXingObjC/ZXGenericMultipleBarcodeReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXGenericMultipleBarcodeReader.h
@@ -1,0 +1,1 @@
+../../multi/ZXGenericMultipleBarcodeReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXGeoParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXGeoParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXGeoParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXGeoResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXGeoResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXGeoResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXGlobalHistogramBinarizer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXGlobalHistogramBinarizer.h
@@ -1,0 +1,1 @@
+../../common/ZXGlobalHistogramBinarizer.h

--- a/ZXingObjC/include/ZXingObjC/ZXGridSampler.h
+++ b/ZXingObjC/include/ZXingObjC/ZXGridSampler.h
@@ -1,0 +1,1 @@
+../../common/ZXGridSampler.h

--- a/ZXingObjC/include/ZXingObjC/ZXHybridBinarizer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXHybridBinarizer.h
@@ -1,0 +1,1 @@
+../../common/ZXHybridBinarizer.h

--- a/ZXingObjC/include/ZXingObjC/ZXISBNParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXISBNParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXISBNParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXISBNResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXISBNResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXISBNResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXITFReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXITFReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXITFReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXITFWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXITFWriter.h
@@ -1,0 +1,1 @@
+../../oned/ZXITFWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXImage.h
+++ b/ZXingObjC/include/ZXingObjC/ZXImage.h
@@ -1,0 +1,1 @@
+../../client/ZXImage.h

--- a/ZXingObjC/include/ZXingObjC/ZXIntArray.h
+++ b/ZXingObjC/include/ZXingObjC/ZXIntArray.h
@@ -1,0 +1,1 @@
+../../common/ZXIntArray.h

--- a/ZXingObjC/include/ZXingObjC/ZXInvertedLuminanceSource.h
+++ b/ZXingObjC/include/ZXingObjC/ZXInvertedLuminanceSource.h
@@ -1,0 +1,1 @@
+../../core/ZXInvertedLuminanceSource.h

--- a/ZXingObjC/include/ZXingObjC/ZXLuminanceSource.h
+++ b/ZXingObjC/include/ZXingObjC/ZXLuminanceSource.h
@@ -1,0 +1,1 @@
+../../core/ZXLuminanceSource.h

--- a/ZXingObjC/include/ZXingObjC/ZXMathUtils.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMathUtils.h
@@ -1,0 +1,1 @@
+../../common/detector/ZXMathUtils.h

--- a/ZXingObjC/include/ZXingObjC/ZXMaxiCodeDecoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMaxiCodeDecoder.h
@@ -1,0 +1,1 @@
+../../maxicode/decoder/ZXMaxiCodeDecoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXMaxiCodeReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMaxiCodeReader.h
@@ -1,0 +1,1 @@
+../../maxicode/ZXMaxiCodeReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXModulusGF.h
+++ b/ZXingObjC/include/ZXingObjC/ZXModulusGF.h
@@ -1,0 +1,1 @@
+../../pdf417/decoder/ec/ZXModulusGF.h

--- a/ZXingObjC/include/ZXingObjC/ZXMonochromeRectangleDetector.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMonochromeRectangleDetector.h
@@ -1,0 +1,1 @@
+../../common/detector/ZXMonochromeRectangleDetector.h

--- a/ZXingObjC/include/ZXingObjC/ZXMultiDetector.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMultiDetector.h
@@ -1,0 +1,1 @@
+../../qrcode/multi/detector/ZXMultiDetector.h

--- a/ZXingObjC/include/ZXingObjC/ZXMultiFormatOneDReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMultiFormatOneDReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXMultiFormatOneDReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXMultiFormatReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMultiFormatReader.h
@@ -1,0 +1,1 @@
+../../ZXMultiFormatReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXMultiFormatUPCEANReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMultiFormatUPCEANReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXMultiFormatUPCEANReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXMultiFormatWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMultiFormatWriter.h
@@ -1,0 +1,1 @@
+../../ZXMultiFormatWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXMultipleBarcodeReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXMultipleBarcodeReader.h
@@ -1,0 +1,1 @@
+../../multi/ZXMultipleBarcodeReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXOneDReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXOneDReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXOneDReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXOneDimensionalCodeWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXOneDimensionalCodeWriter.h
@@ -1,0 +1,1 @@
+../../oned/ZXOneDimensionalCodeWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417.h
@@ -1,0 +1,1 @@
+../../pdf417/encoder/ZXPDF417.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417BarcodeMatrix.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417BarcodeMatrix.h
@@ -1,0 +1,1 @@
+../../pdf417/encoder/ZXPDF417BarcodeMatrix.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417Common.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417Common.h
@@ -1,0 +1,1 @@
+../../pdf417/ZXPDF417Common.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417Detector.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417Detector.h
@@ -1,0 +1,1 @@
+../../pdf417/detector/ZXPDF417Detector.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417DetectorResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417DetectorResult.h
@@ -1,0 +1,1 @@
+../../pdf417/detector/ZXPDF417DetectorResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417Dimensions.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417Dimensions.h
@@ -1,0 +1,1 @@
+../../pdf417/encoder/ZXPDF417Dimensions.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417ECErrorCorrection.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417ECErrorCorrection.h
@@ -1,0 +1,1 @@
+../../pdf417/decoder/ec/ZXPDF417ECErrorCorrection.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417Reader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417Reader.h
@@ -1,0 +1,1 @@
+../../pdf417/ZXPDF417Reader.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417ResultMetadata.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417ResultMetadata.h
@@ -1,0 +1,1 @@
+../../pdf417/ZXPDF417ResultMetadata.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417ScanningDecoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417ScanningDecoder.h
@@ -1,0 +1,1 @@
+../../pdf417/decoder/ZXPDF417ScanningDecoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXPDF417Writer.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPDF417Writer.h
@@ -1,0 +1,1 @@
+../../pdf417/ZXPDF417Writer.h

--- a/ZXingObjC/include/ZXingObjC/ZXParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXParsedResultType.h
+++ b/ZXingObjC/include/ZXingObjC/ZXParsedResultType.h
@@ -1,0 +1,1 @@
+../../client/result/ZXParsedResultType.h

--- a/ZXingObjC/include/ZXingObjC/ZXPerspectiveTransform.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPerspectiveTransform.h
@@ -1,0 +1,1 @@
+../../common/ZXPerspectiveTransform.h

--- a/ZXingObjC/include/ZXingObjC/ZXPlanarYUVLuminanceSource.h
+++ b/ZXingObjC/include/ZXingObjC/ZXPlanarYUVLuminanceSource.h
@@ -1,0 +1,1 @@
+../../core/ZXPlanarYUVLuminanceSource.h

--- a/ZXingObjC/include/ZXingObjC/ZXProductParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXProductParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXProductParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXProductResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXProductResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXProductResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCode.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCode.h
@@ -1,0 +1,1 @@
+../../qrcode/encoder/ZXQRCode.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeAlignmentPattern.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeAlignmentPattern.h
@@ -1,0 +1,1 @@
+../../qrcode/detector/ZXQRCodeAlignmentPattern.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeDecoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeDecoder.h
@@ -1,0 +1,1 @@
+../../qrcode/decoder/ZXQRCodeDecoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeDecoderMetaData.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeDecoderMetaData.h
@@ -1,0 +1,1 @@
+../../qrcode/decoder/ZXQRCodeDecoderMetaData.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeDetector.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeDetector.h
@@ -1,0 +1,1 @@
+../../qrcode/detector/ZXQRCodeDetector.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeEncoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeEncoder.h
@@ -1,0 +1,1 @@
+../../qrcode/encoder/ZXQRCodeEncoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeErrorCorrectionLevel.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeErrorCorrectionLevel.h
@@ -1,0 +1,1 @@
+../../qrcode/decoder/ZXQRCodeErrorCorrectionLevel.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeFinderPattern.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeFinderPattern.h
@@ -1,0 +1,1 @@
+../../qrcode/detector/ZXQRCodeFinderPattern.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeFinderPatternFinder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeFinderPatternFinder.h
@@ -1,0 +1,1 @@
+../../qrcode/detector/ZXQRCodeFinderPatternFinder.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeFinderPatternInfo.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeFinderPatternInfo.h
@@ -1,0 +1,1 @@
+../../qrcode/detector/ZXQRCodeFinderPatternInfo.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeMode.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeMode.h
@@ -1,0 +1,1 @@
+../../qrcode/decoder/ZXQRCodeMode.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeMultiReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeMultiReader.h
@@ -1,0 +1,1 @@
+../../qrcode/multi/ZXQRCodeMultiReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeReader.h
@@ -1,0 +1,1 @@
+../../qrcode/ZXQRCodeReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeVersion.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeVersion.h
@@ -1,0 +1,1 @@
+../../qrcode/decoder/ZXQRCodeVersion.h

--- a/ZXingObjC/include/ZXingObjC/ZXQRCodeWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXQRCodeWriter.h
@@ -1,0 +1,1 @@
+../../qrcode/ZXQRCodeWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXRGBLuminanceSource.h
+++ b/ZXingObjC/include/ZXingObjC/ZXRGBLuminanceSource.h
@@ -1,0 +1,1 @@
+../../core/ZXRGBLuminanceSource.h

--- a/ZXingObjC/include/ZXingObjC/ZXRSS14Reader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXRSS14Reader.h
@@ -1,0 +1,1 @@
+../../oned/rss/ZXRSS14Reader.h

--- a/ZXingObjC/include/ZXingObjC/ZXRSSDataCharacter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXRSSDataCharacter.h
@@ -1,0 +1,1 @@
+../../oned/rss/ZXRSSDataCharacter.h

--- a/ZXingObjC/include/ZXingObjC/ZXRSSExpandedReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXRSSExpandedReader.h
@@ -1,0 +1,1 @@
+../../oned/rss/expanded/ZXRSSExpandedReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXRSSFinderPattern.h
+++ b/ZXingObjC/include/ZXingObjC/ZXRSSFinderPattern.h
@@ -1,0 +1,1 @@
+../../oned/rss/ZXRSSFinderPattern.h

--- a/ZXingObjC/include/ZXingObjC/ZXRSSUtils.h
+++ b/ZXingObjC/include/ZXingObjC/ZXRSSUtils.h
@@ -1,0 +1,1 @@
+../../oned/rss/ZXRSSUtils.h

--- a/ZXingObjC/include/ZXingObjC/ZXReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXReader.h
@@ -1,0 +1,1 @@
+../../core/ZXReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXReedSolomonDecoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXReedSolomonDecoder.h
@@ -1,0 +1,1 @@
+../../common/reedsolomon/ZXReedSolomonDecoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXReedSolomonEncoder.h
+++ b/ZXingObjC/include/ZXingObjC/ZXReedSolomonEncoder.h
@@ -1,0 +1,1 @@
+../../common/reedsolomon/ZXReedSolomonEncoder.h

--- a/ZXingObjC/include/ZXingObjC/ZXResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXResult.h
@@ -1,0 +1,1 @@
+../../core/ZXResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXResultMetadataType.h
+++ b/ZXingObjC/include/ZXingObjC/ZXResultMetadataType.h
@@ -1,0 +1,1 @@
+../../core/ZXResultMetadataType.h

--- a/ZXingObjC/include/ZXingObjC/ZXResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXResultPoint.h
+++ b/ZXingObjC/include/ZXingObjC/ZXResultPoint.h
@@ -1,0 +1,1 @@
+../../core/ZXResultPoint.h

--- a/ZXingObjC/include/ZXingObjC/ZXResultPointCallback.h
+++ b/ZXingObjC/include/ZXingObjC/ZXResultPointCallback.h
@@ -1,0 +1,1 @@
+../../core/ZXResultPointCallback.h

--- a/ZXingObjC/include/ZXingObjC/ZXSMSMMSResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXSMSMMSResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXSMSMMSResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXSMSParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXSMSParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXSMSParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXSMSTOMMSTOResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXSMSTOMMSTOResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXSMSTOMMSTOResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXSMTPResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXSMTPResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXSMTPResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXStringUtils.h
+++ b/ZXingObjC/include/ZXingObjC/ZXStringUtils.h
@@ -1,0 +1,1 @@
+../../common/ZXStringUtils.h

--- a/ZXingObjC/include/ZXingObjC/ZXTelParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXTelParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXTelParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXTelResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXTelResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXTelResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXTextParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXTextParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXTextParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXUPCAReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXUPCAReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXUPCAReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXUPCAWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXUPCAWriter.h
@@ -1,0 +1,1 @@
+../../oned/ZXUPCAWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXUPCEANReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXUPCEANReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXUPCEANReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXUPCEANWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXUPCEANWriter.h
@@ -1,0 +1,1 @@
+../../oned/ZXUPCEANWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXUPCEReader.h
+++ b/ZXingObjC/include/ZXingObjC/ZXUPCEReader.h
@@ -1,0 +1,1 @@
+../../oned/ZXUPCEReader.h

--- a/ZXingObjC/include/ZXingObjC/ZXUPCEWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXUPCEWriter.h
@@ -1,0 +1,1 @@
+../../oned/ZXUPCEWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXURIParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXURIParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXURIParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXURIResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXURIResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXURIResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXURLTOResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXURLTOResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXURLTOResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXVCardResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXVCardResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXVCardResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXVEventResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXVEventResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXVEventResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXVINParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXVINParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXVINParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXVINResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXVINResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXVINResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXWhiteRectangleDetector.h
+++ b/ZXingObjC/include/ZXingObjC/ZXWhiteRectangleDetector.h
@@ -1,0 +1,1 @@
+../../common/detector/ZXWhiteRectangleDetector.h

--- a/ZXingObjC/include/ZXingObjC/ZXWifiParsedResult.h
+++ b/ZXingObjC/include/ZXingObjC/ZXWifiParsedResult.h
@@ -1,0 +1,1 @@
+../../client/result/ZXWifiParsedResult.h

--- a/ZXingObjC/include/ZXingObjC/ZXWifiResultParser.h
+++ b/ZXingObjC/include/ZXingObjC/ZXWifiResultParser.h
@@ -1,0 +1,1 @@
+../../client/result/ZXWifiResultParser.h

--- a/ZXingObjC/include/ZXingObjC/ZXWriter.h
+++ b/ZXingObjC/include/ZXingObjC/ZXWriter.h
@@ -1,0 +1,1 @@
+../../core/ZXWriter.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjC.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjC.h
@@ -1,0 +1,1 @@
+../../ZXingObjC.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjCAztec.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjCAztec.h
@@ -1,0 +1,1 @@
+../../aztec/ZXingObjCAztec.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjCCore.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjCCore.h
@@ -1,0 +1,1 @@
+../../core/ZXingObjCCore.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjCDataMatrix.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjCDataMatrix.h
@@ -1,0 +1,1 @@
+../../datamatrix/ZXingObjCDataMatrix.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjCMaxiCode.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjCMaxiCode.h
@@ -1,0 +1,1 @@
+../../maxicode/ZXingObjCMaxiCode.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjCOneD.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjCOneD.h
@@ -1,0 +1,1 @@
+../../oned/ZXingObjCOneD.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjCPDF417.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjCPDF417.h
@@ -1,0 +1,1 @@
+../../pdf417/ZXingObjCPDF417.h

--- a/ZXingObjC/include/ZXingObjC/ZXingObjCQRCode.h
+++ b/ZXingObjC/include/ZXingObjC/ZXingObjCQRCode.h
@@ -1,0 +1,1 @@
+../../qrcode/ZXingObjCQRCode.h

--- a/ZXingObjC/include/module.modulemap
+++ b/ZXingObjC/include/module.modulemap
@@ -1,0 +1,5 @@
+module ZXingObjC {
+    umbrella header "ZXingObjC/ZXingObjC.h"
+    export *
+    module * { export * }
+}

--- a/ZXingObjC/oned/ZXEANManufacturerOrgSupport.h
+++ b/ZXingObjC/oned/ZXEANManufacturerOrgSupport.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Records EAN prefix to GS1 Member Organization, where the member organization
  * correlates strongly with a country. This is an imperfect means of identifying

--- a/ZXingObjC/oned/ZXUPCEANExtensionSupport.h
+++ b/ZXingObjC/oned/ZXUPCEANExtensionSupport.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitArray, ZXResult;
 
 @interface ZXUPCEANExtensionSupport : NSObject

--- a/ZXingObjC/oned/rss/ZXRSSDataCharacter.h
+++ b/ZXingObjC/oned/rss/ZXRSSDataCharacter.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXRSSDataCharacter : NSObject
 
 @property (nonatomic, assign, readonly) int value;

--- a/ZXingObjC/oned/rss/expanded/ZXRSSExpandedRow.h
+++ b/ZXingObjC/oned/rss/expanded/ZXRSSExpandedRow.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * One row of an RSS Expanded Stacked symbol, consisting of 1+ expanded pairs.
  */

--- a/ZXingObjC/oned/rss/expanded/decoders/ZXAbstractExpandedDecoder.h
+++ b/ZXingObjC/oned/rss/expanded/decoders/ZXAbstractExpandedDecoder.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitArray, ZXRSSExpandedGeneralAppIdDecoder;
 
 @interface ZXAbstractExpandedDecoder : NSObject

--- a/ZXingObjC/oned/rss/expanded/decoders/ZXRSSExpandedBlockParsedResult.h
+++ b/ZXingObjC/oned/rss/expanded/decoders/ZXRSSExpandedBlockParsedResult.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXRSSExpandedDecodedInformation;
 
 @interface ZXRSSExpandedBlockParsedResult : NSObject

--- a/ZXingObjC/oned/rss/expanded/decoders/ZXRSSExpandedCurrentParsingState.h
+++ b/ZXingObjC/oned/rss/expanded/decoders/ZXRSSExpandedCurrentParsingState.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXRSSExpandedCurrentParsingState : NSObject
 
 @property (nonatomic, assign) int position;

--- a/ZXingObjC/oned/rss/expanded/decoders/ZXRSSExpandedDecodedObject.h
+++ b/ZXingObjC/oned/rss/expanded/decoders/ZXRSSExpandedDecodedObject.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXRSSExpandedDecodedObject : NSObject
 
 @property (nonatomic, assign, readonly) int theNewPosition;

--- a/ZXingObjC/pdf417/ZXPDF417ResultMetadata.h
+++ b/ZXingObjC/pdf417/ZXPDF417ResultMetadata.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXPDF417ResultMetadata : NSObject
 
 @property (nonatomic, assign) int segmentIndex;

--- a/ZXingObjC/pdf417/decoder/ZXPDF417BarcodeMetadata.h
+++ b/ZXingObjC/pdf417/decoder/ZXPDF417BarcodeMetadata.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXPDF417BarcodeMetadata : NSObject
 
 @property (nonatomic, assign, readonly) int columnCount;

--- a/ZXingObjC/pdf417/decoder/ZXPDF417BarcodeValue.h
+++ b/ZXingObjC/pdf417/decoder/ZXPDF417BarcodeValue.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXIntArray;
 
 @interface ZXPDF417BarcodeValue : NSObject

--- a/ZXingObjC/pdf417/decoder/ZXPDF417BoundingBox.h
+++ b/ZXingObjC/pdf417/decoder/ZXPDF417BoundingBox.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitMatrix, ZXResultPoint;
 
 @interface ZXPDF417BoundingBox : NSObject

--- a/ZXingObjC/pdf417/decoder/ZXPDF417Codeword.h
+++ b/ZXingObjC/pdf417/decoder/ZXPDF417Codeword.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXPDF417Codeword : NSObject
 
 @property (nonatomic, assign, readonly) int startX;

--- a/ZXingObjC/pdf417/decoder/ZXPDF417CodewordDecoder.h
+++ b/ZXingObjC/pdf417/decoder/ZXPDF417CodewordDecoder.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @interface ZXPDF417CodewordDecoder : NSObject
 
 + (int)decodedValue:(NSArray *)moduleBitCount;

--- a/ZXingObjC/pdf417/decoder/ec/ZXPDF417ECErrorCorrection.h
+++ b/ZXingObjC/pdf417/decoder/ec/ZXPDF417ECErrorCorrection.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXIntArray;
 
 /**

--- a/ZXingObjC/pdf417/detector/ZXPDF417DetectorResult.h
+++ b/ZXingObjC/pdf417/detector/ZXPDF417DetectorResult.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXBitMatrix;
 
 @interface ZXPDF417DetectorResult : NSObject

--- a/ZXingObjC/pdf417/encoder/ZXPDF417BarcodeMatrix.h
+++ b/ZXingObjC/pdf417/encoder/ZXPDF417BarcodeMatrix.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXPDF417BarcodeRow;
 
 /**

--- a/ZXingObjC/pdf417/encoder/ZXPDF417Dimensions.h
+++ b/ZXingObjC/pdf417/encoder/ZXPDF417Dimensions.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Data object to specify the minimum and maximum number of rows and columns for a PDF417 barcode.
  */

--- a/ZXingObjC/qrcode/decoder/ZXQRCodeDecoderMetaData.h
+++ b/ZXingObjC/qrcode/decoder/ZXQRCodeDecoderMetaData.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * Meta-data container for QR Code decoding. Instances of this class may be used to convey information back to the
  * decoding caller. Callers are expected to process this.

--- a/ZXingObjC/qrcode/decoder/ZXQRCodeErrorCorrectionLevel.h
+++ b/ZXingObjC/qrcode/decoder/ZXQRCodeErrorCorrectionLevel.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * See ISO 18004:2006, 6.5.1. This enum encapsulates the four error correction levels
  * defined by the QR code standard.

--- a/ZXingObjC/qrcode/decoder/ZXQRCodeMode.h
+++ b/ZXingObjC/qrcode/decoder/ZXQRCodeMode.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXQRCodeVersion;
 
 /**

--- a/ZXingObjC/qrcode/encoder/ZXQRCodeBlockPair.h
+++ b/ZXingObjC/qrcode/encoder/ZXQRCodeBlockPair.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 @class ZXByteArray;
 
 @interface ZXQRCodeBlockPair : NSObject


### PR DESCRIPTION
Hey, 

Now that Xcode 11 is out with support for Swift Package Manager, some people including me, are trying to migrate from Cocoapods or Carthage to Swift Package Manager, so this PR add's support for it, and it fixes https://github.com/zxingify/zxingify-objc/issues/488 opened by me.

Thanks

