### PR TITLE
Fixed Carthage installation example with the correct format

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ We highly recommend Carthage as module manager.
 ZXingObjC can be installed using [Carthage](https://github.com/Carthage/Carthage). After installing Carthage just add ZXingObjC to your Cartfile:
 
 ```ogdl
-github "TheLevelUp/ZXingObjC" ~> 3.6
+github "zxingify/zxingify-objc" ~> 3.6
 ```
 
 #### CocoaPods


### PR DESCRIPTION
Previous Carthage example was pointing to the old repo. Now the example uses the correct repo for installation.