### PR TITLE
fix decoding of special characters in TEXT and C40 blocks

### DIFF
--- a/ZXingObjC/datamatrix/decoder/ZXDataMatrixDecodedBitStreamParser.m
+++ b/ZXingObjC/datamatrix/decoder/ZXDataMatrixDecodedBitStreamParser.m
@@ -243,7 +243,7 @@ enum {
         shift = 0;
         break;
       case 2:
-        if (cValue < sizeof(C40_SHIFT2_SET_CHARS) / sizeof(unichar)) {
+        if (cValue < 27) {
           unichar c40char = C40_SHIFT2_SET_CHARS[cValue];
           if (upperShift) {
             [result appendFormat:@"%C", (unichar)(c40char + 128)];
@@ -331,7 +331,7 @@ enum {
         break;
       case 2:
           // Shift 2 for Text is the same encoding as C40
-        if (cValue < sizeof(TEXT_SHIFT2_SET_CHARS) / sizeof(unichar)) {
+        if (cValue < 27) {
           unichar textChar = TEXT_SHIFT2_SET_CHARS[cValue];
           if (upperShift) {
             [result appendFormat:@"%C", (unichar)(textChar + 128)];


### PR DESCRIPTION
This PR fixes the interpretation of FNC1 characters (and others) in TEXT and C40 blocks.

This bug is genuine to the iOS port and caused by the different semantics of `Array.length` in Java and `sizeof(array)` in Objective-C (for technical details see the commit message). 
The bug occured in examples of russian cryptocodes (obligatory Datamatrix codes for pharmaceuticals in Russia), which appear to have FNC1 characters in the content. 

It might be advisable to check for other incorrect usages of sizeof in the codebase.
