### PR TITLE
Fix Xcode warnings ("Skipping duplicate build file...")

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ github "TheLevelUp/ZXingObjC" ~> 3.6
 
 ```ruby
 platform :ios, '8.0'
-pod 'ZXingObjC', '~> 3.6.4'
+pod 'ZXingObjC', '~> 3.6.8'
 ```
 
 ## Examples

--- a/ZXingObjC.podspec
+++ b/ZXingObjC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ZXingObjC'
-  s.version = '3.6.5'
+  s.version = '3.6.8'
   s.summary = 'An Objective-C Port of the ZXing barcode framework.'
   s.homepage = 'https://github.com/zxingify/zxingify-objc'
   s.author = 'zxingify'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.xcconfig = { "OTHER_LDFLAGS" => "-ObjC" }
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.8'
 
   s.ios.frameworks = 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'ImageIO', 'QuartzCore'
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'All' do |ss|
     ss.source_files = 'ZXingObjC/**/*.{h,m}'
+    ss.exclude_files = 'ZXingObjC/include/**/*.h'
   end
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
The change in the default subspec `All` will prevent that the symbolic links for the headers in `ZXingObjC/inlcude` will be added twice to the `Headers` build phase.

Additional, Xcode12 resp. cocoapods will warn, if a pod has min deployment target < 9.0.