### PR TITLE
Adding linker flag for code coverage to prevent '

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ZXingObjC.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ZXingObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,24 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DB72547E1A523C9200EFF81B"
-               BuildableName = "ZXingObjC.framework"
-               BlueprintName = "iOS Framework"
-               ReferencedContainer = "container:ZXingObjC.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DB7254881A523C9200EFF81B"
-               BuildableName = "iOS FrameworkTests.xctest"
-               BlueprintName = "iOS FrameworkTests"
-               ReferencedContainer = "container:ZXingObjC.xcodeproj">
+               BlueprintIdentifier = "ZXingObjC"
+               BuildableName = "ZXingObjC"
+               BlueprintName = "ZXingObjC"
+               ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -41,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB72547E1A523C9200EFF81B"
-            BuildableName = "ZXingObjC.framework"
-            BlueprintName = "iOS Framework"
-            ReferencedContainer = "container:ZXingObjC.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>
@@ -63,15 +40,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB72547E1A523C9200EFF81B"
-            BuildableName = "ZXingObjC.framework"
-            BlueprintName = "iOS Framework"
-            ReferencedContainer = "container:ZXingObjC.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -82,10 +50,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB72547E1A523C9200EFF81B"
-            BuildableName = "ZXingObjC.framework"
-            BlueprintName = "iOS Framework"
-            ReferencedContainer = "container:ZXingObjC.xcodeproj">
+            BlueprintIdentifier = "ZXingObjC"
+            BuildableName = "ZXingObjC"
+            BlueprintName = "ZXingObjC"
+            ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>

--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,9 @@ let package = Package(
                 .headerSearchPath("qrcode/encoder"),
                 .headerSearchPath("qrcode/multi"),
                 .headerSearchPath("qrcode/multi/detector"),
+            ],
+            linkerSettings: [
+              .unsafeFlags(["-fprofile-instr-generate"])
             ]
         )
     ]

--- a/ZXingObjC.xcodeproj/project.pbxproj
+++ b/ZXingObjC.xcodeproj/project.pbxproj
@@ -3218,7 +3218,6 @@
 				25403CB9166A96FA00E13304 /* Supporting Files */,
 				25403CB5166A96FA00E13304 /* iOS Frameworks */,
 				2540438A166AB8EA00E13304 /* OS X Frameworks */,
-				DB7254801A523C9200EFF81B /* iOS Framework */,
 				25403CB4166A96FA00E13304 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -4369,13 +4368,6 @@
 			path = additional;
 			sourceTree = "<group>";
 		};
-		DB7254801A523C9200EFF81B /* iOS Framework */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "iOS Framework";
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -5500,6 +5492,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 25403CA8166A96F900E13304;

--- a/ZXingObjC.xcodeproj/xcshareddata/xcschemes/ZXingObjC-iOS.xcscheme
+++ b/ZXingObjC.xcodeproj/xcshareddata/xcschemes/ZXingObjC-iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +40,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "024D10DA156EAB6F00FE6872"
-            BuildableName = "BarcodeScanner.app"
-            BlueprintName = "BarcodeScanner"
-            ReferencedContainer = "container:examples/BarcodeScanner/BarcodeScanner.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +60,6 @@
             ReferencedContainer = "container:ZXingObjC.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
While trying to use ZXingify-objc in my project through SPM (as opposed to Cocoapods) I ran into the following crash

Undefined symbols for architecture x86_64
Symbol: ___llvm_profile_runtime
Referenced from: ___llvm_profile_runtime_user in ZXingObjC.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

Upon investigation I needed to add a change to the Package.swift file to enable the project to compile